### PR TITLE
do a deep copy of argv

### DIFF
--- a/farm.coffee
+++ b/farm.coffee
@@ -46,9 +46,16 @@ module.exports = exports = (argv) ->
     else
       # Create a new options object, copy over the options used to start the
       # farm, and modify them to make sense for servers spawned from the farm.
-      newargv = {}
-      for key, value of argv
-        newargv[key] = value
+
+      # do deep copy, needed for database configuration for instance
+      copy = (map) ->
+          clone  = {}
+          for key, value of map
+            clone[key] = if typeof value == "object" then copy(value) else value
+          clone
+
+      newargv = copy argv
+
       newargv.data = if argv.data
         path.join(argv.data, incHost.split(':')[0])
       else


### PR DESCRIPTION
I was unable to lounch multiple couchdb backed wikis in farming mode since database:type had been changed from couchdb to wiki-storage-couchdb for the first instance and to wiki-storage-wiki-storage-couchdb for the second and so on.

This patch gives every server a completely cloned config.